### PR TITLE
fix: add NPM_TOKEN to ~/.npmrc to fix snapshot publishing

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -25,8 +25,11 @@ jobs:
           distribution: corretto
           java-version: 8
           cache: sbt
+
+      - name: Create .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: 'echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN\n" >> $HOME/.npmrc'
       
       - name: Release Snapshot to NPM
         run: scripts/ci/release-snapshot-npm.sh
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What does this change?

- Adds `NPM_TOKEN` to the GitHub Action runner's `~/.npmrc` file so the `npm publish` step works

## Why?

The snapshot publish workflow does not use the "changsets publish" functionality, which [automatically sets the npm token](https://github.com/changesets/action/blob/main/src/index.ts#L59) in the home directory's `.npmrc` file. This change will set the npm token, enabling the `npm publish` step to work for snapshots
