### PR TITLE
Scala snapshot releases

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -5,22 +5,20 @@ on:
     types: [published]
 
 jobs:
-  release_npm:
-    name: Release to npm
+  check_is_snapshot:
     runs-on: ubuntu-latest
     if: "github.event.release.prerelease"
-
+  
+  release_npm:
+    needs: check_is_snapshot
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-
-      - name: Setup JDK
-        uses: actions/setup-java@v3
+      - uses: actions/setup-java@v3
         with:
           distribution: corretto
           java-version: 8
@@ -30,3 +28,24 @@ jobs:
         run: scripts/ci/release-snapshot-npm.sh
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    
+  release_sonatype:
+    runs-on: ubuntu-latest
+    needs: check_is_snapshot
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 8
+          cache: sbt
+
+      - name: Release Snapshot to Sonatype
+        run: |
+          scripts/ci/configure/gpg.sh
+          scripts/ci/release-snapshot-sonatype.sh
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -27,8 +27,6 @@ jobs:
       
       - name: Release Snapshot to NPM
         run: scripts/ci/release-snapshot-npm.sh
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     
   release_sonatype:
     if: "github.event.release.prerelease"

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Release Snapshot to Sonatype
         run: |
-          scripts/ci/configure/gpg.sh
+          scripts/ci/configure-gpg.sh
           scripts/ci/release-snapshot-sonatype.sh
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -5,12 +5,8 @@ on:
     types: [published]
 
 jobs:
-  check_is_snapshot:
-    runs-on: ubuntu-latest
-    if: "github.event.release.prerelease"
-  
   release_npm:
-    needs: check_is_snapshot
+    if: "github.event.release.prerelease"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,8 +26,8 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     
   release_sonatype:
+    if: "github.event.release.prerelease"
     runs-on: ubuntu-latest
-    needs: check_is_snapshot
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ To create a changeset, ensure you are using the correct Node (and associated npm
 - When your feature PR is merged to `main`, the [changesets action](.github/workflows/changesets.yaml) will open a PR against `main` with the details of all unreleased changes. This is a "Release PR"
 - When ready to release, merge the Release PR
 
-## How to release a Snapshot to NPM
+## How to release a Snapshot to NPM and Sonatype
 
 - Create a branch which has the changes you want to test
 - Create a **Prerelease** using GitHub Releases
     - Set the Target to your branch
-    - You must also create a tag for the snapshot release. For example, `v0.0.0-2022-10-20-SNAPSHOT`
-    - To automatically release the snapshot to `npm`, publish the prerelease
+    - You must also create a tag for the snapshot release. Use the following format: `v0.0.0-YYYY-MM-DD-SNAPSHOT`. For example, `v0.0.0-2022-10-20-SNAPSHOT`. It is important the tag **begins** with `v` and **ends** with `-SNAPSHOT`.
+    - To automatically release the snapshot to `npm` and `sonatype`, publish the prerelease
     - Snapshots are released to the `snapshot` tag on `npm`. You can install them with `npm install @guardian/apps-rendering-api-models@snapshot`
 
 ## How to release to Sonatype
 
 Prerequisites:
 
-- have a Sonatype account with access to the guardian organisation
+- a Sonatype account with access to the guardian organisation
 
 Steps:
 

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,8 @@ lazy val scalaApiModels = project.in(file("models") / "scala")
     ) ++ libraryDeps,
 
     publishTo := sonatypePublishToBundle.value,
+    // If you are publishing with a Sonatype account created before 2021-02-28, delete this sonatypeCredentialHost override
+    sonatypeCredentialHost := "s01.oss.sonatype.org",
 
     scmInfo := Some(ScmInfo(
       url("https://github.com/guardian/apps-rendering-api-models"),

--- a/scripts/ci/configure-gpg.sh
+++ b/scripts/ci/configure-gpg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+echo $PGP_SECRET | base64 --decode | gpg --batch --import

--- a/scripts/ci/release-snapshot-sonatype.sh
+++ b/scripts/ci/release-snapshot-sonatype.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+pushd $(dirname $0)
+VERSION=$(./get-version.sh)
+popd
+
+# If we are in CI and this is a snapshot release, we should get the version from the tag created in the GitHub Release
+if [[ $CI ]] ; then
+    VERSION=$(git describe --tags)
+fi
+
+# Strip a leading "v" character, so "v0.0.0 => 0.0.0"
+if [[ ${VERSION:0:1} == "v" ]] ; then
+    VERSION=${VERSION:1}
+fi
+
+# sbt-release uses -SNAPSHOT suffix to make the release to the SNAPSHOT channel
+if [[ ${VERSION: -9} != "-SNAPSHOT" ]] ; then
+    echo "Version must end in -SNAPSHOT. Adding -SNAPSHOT suffix"
+    VERSION="$VERSION-SNAPSHOT"
+fi
+
+echo "Releasing version $VERSION Sonatype as snapshot"
+sbt "clean" "project scalaApiModels" "release release-version $VERSION with-defaults"


### PR DESCRIPTION
## What does this change?

- Adds a job to the `release_snapshot` GitHub Action workflow to release a snapshot to sonatype
- Adds a script to release a snapshot to sonatype
- Updates the README with information about releasing Sonatype snapshots
