### PR TITLE
fix: set npm registry and auth token environment variable

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup JDK
         uses: actions/setup-java@v3
@@ -25,11 +26,8 @@ jobs:
           distribution: corretto
           java-version: 8
           cache: sbt
-
-      - name: Create .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: 'echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN\n" >> $HOME/.npmrc'
       
       - name: Release Snapshot to NPM
         run: scripts/ci/release-snapshot-npm.sh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -28,6 +28,8 @@ jobs:
           cache: sbt
       
       - name: Release Snapshot to NPM
-        run: scripts/ci/release-snapshot-npm.sh
+        run: |
+          npm config set ignore-scripts true
+          scripts/ci/release-snapshot-npm.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What does this change?

- Uses `actions/setup-node@v3` with a `registry-url` which is required for publishing ([docs](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm))
- Assigns the `NPM_TOKEN` repository secret to the `NODE_AUTH_TOKEN` environment variable when running the publish step

## How to test

- A modified version of the changes were successfully tested in [this workflow run](https://github.com/guardian/apps-rendering-api-models/actions/runs/3363222522) associated with #8