### PR TITLE
Fix sonatype snapshot

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,8 +45,6 @@ lazy val scalaApiModels = project.in(file("models") / "scala")
     ) ++ libraryDeps,
 
     publishTo := sonatypePublishToBundle.value,
-    // If you are publishing with a Sonatype account created before 2021-02-28, delete this sonatypeCredentialHost override
-    sonatypeCredentialHost := "s01.oss.sonatype.org",
 
     scmInfo := Some(ScmInfo(
       url("https://github.com/guardian/apps-rendering-api-models"),

--- a/build.sbt
+++ b/build.sbt
@@ -60,15 +60,21 @@ lazy val scalaApiModels = project.in(file("models") / "scala")
       url = url("https://github.com/guardian")
     )),
 
-    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,
       runClean,
       runTest,
       setReleaseVersion,
-      publishArtifacts,
-      releaseStepCommand("sonatypeBundleRelease")
+      releaseStepCommand("publishSigned"),
+      ReleaseStep(action = st => {
+        // sonatypeBundleRelease should only be called if we are not doing a snapshot release
+        // see: https://github.com/xerial/sbt-sonatype/blob/33b6ea4e5a6ca519213f20c349a8a4f57171929a/README.md#buildsbt
+        if (!isSnapshot.value) {
+          releaseStepCommand("sonatypeBundleRelease")
+        }
+        st
+      }),
     )
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "2.0.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 


### PR DESCRIPTION
## What does this change?

- Bumps `sbt-pgp` to `2.1.2`
- Only runs `sonatypeBundleRelease` if **not** releasing a snapshot. Otherwise, this step fails
  - when releasing a snapshot, the `publishSigned` step uploads the artifacts to maven
- Removes the credential host override

## How to test

These changes have been tested manually:

- [Successful GitHub Action run](https://github.com/guardian/apps-rendering-api-models/actions/runs/3376884189/jobs/5605145137)
- [Released snapshot in Sonatype](https://oss.sonatype.org/content/repositories/snapshots/com/gu/apps-rendering-api-models_2.12/0.0.0-2022-11-01.2-SNAPSHOT/)