### PR TITLE
More Campaign Types

### DIFF
--- a/.changeset/small-gifts-call.md
+++ b/.changeset/small-gifts-call.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": major
+---
+
+Alters the `campaigns` field to provide a list of all possible campaign types. Previously this field only included "participation" (or "callout") campaigns.

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -60,6 +60,11 @@ struct Branding {
     7: required string aboutUri
 }
 
+struct SurveyQuestion {
+    1: required string question
+    2: required bool askWhy
+}
+
 struct FormOption {
     1: required string label
     2: required string value
@@ -75,13 +80,50 @@ struct FormField {
     7: required list<FormOption> options
 }
 
-struct Fields {
+struct EmailFields {
+    1: required string name
+    2: required string theme
+    3: required string about
+    4: required string description
+    5: required string frequency
+    6: required string listId
+}
+
+struct BadgeFields {
+    1: required string seriesTag
+    2: required string imageUrl
+    3: optional string classModifier
+}
+
+struct EpicFields {
+    1: required string campaignId
+}
+
+struct ReportFields {
+    1: required string campaignId
+}
+
+struct SurveyFields {
+    1: required string campaignId
+    2: required list<SurveyQuestion> questions
+}
+
+struct ParticipationFields {
     1: required string callout
     2: required i32 formId
     3: required string tagName
     4: optional string description
     5: required list<FormField> formFields
     6: optional string formUrl
+}
+
+union CampaignFields {
+    1: EmailFields email
+    2: BadgeFields badge
+    3: EpicFields epic
+    4: ReportFields report
+    5: SurveyFields survey
+    6: ParticipationFields callout
 }
 
 struct Campaign {
@@ -91,7 +133,7 @@ struct Campaign {
     4: optional i64 activeFrom
     5: optional i64 activeUntil
     6: required bool displayOnSensitive
-    7: required Fields fields
+    7: required CampaignFields fields
 }
 
 struct Scorer {
@@ -134,9 +176,14 @@ struct RenderingRequest {
     3: optional bool specialReport
     4: optional map<string,string> targetingParams
     5: optional Branding branding
-    6: optional list<Campaign> campaigns
+    /*
+     * Replaced by field number 11, also called "campaigns".
+     * That field contains more possible types of campaign.
+     */
+    // 6: optional list<Campaign> campaigns
     7: optional RelatedContent relatedContent
     8: optional FootballContent footballContent
     9: optional Edition edition
     10: optional Newsletter promotedNewsletter
+    11: optional list<Campaign> campaigns
 }


### PR DESCRIPTION
## Why?

Part of the work required for https://github.com/guardian/dotcom-rendering/issues/6202. There are several different types of campaigns which MAPI understands. The current `campaigns` field only allows for one of these, callouts (or "participation campaigns"), to be passed through to AR. We would like access to report campaigns to handle special reports and special report alts. This adds support for these, and also for all the other types of campaigns for future use.

### A New `campaigns` Field

We can't alter the existing campaign types. MAPI and AR both depend on these models and are deployed independently, which means that they will briefly be on different versions when we roll these changes out. If we alter existing fields then AR won't understand the data being sent by MAPI during the brief window that they're out of sync.

However, because the existing `campaigns` field is optional, we can deprecate it and replace it with a new optional `campaigns` field containing the changes. Thrift is able to parse missing optional fields as `null` (or another language equivalent), and new optional fields that aren't understood will be ignored.

I've used the same convention as the CAPI models [^1] for deprecating a field: commenting it out and adding an explanation for why it's been removed.

### Thrift Unions

Campaign fields are an example of a sum type: they're **either** callout fields, **or** report fields, **or** badge fields, **or**... and so on. Thrift is able to model sum types using `union` [^2], and our `scrooge-extras` library generates [^3] TypeScript discriminated unions [^4] from this.

## Changes

- Added email, badge, epic, report and survey campaigns
- Created a union type for campaign fields
- Replaced the old "campaigns" field with a new one

[^1]: https://github.com/guardian/content-api-models
[^2]: https://thrift.apache.org/docs/idl#union
[^3]: https://github.com/guardian/scrooge-extras/blob/main/README.md#union
[^4]: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions
