### PR TITLE
Release to npm and sonatype

### DIFF
--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -24,7 +24,11 @@ jobs:
         uses: changesets/action@v1
         with:
           version: npm run version
-          publish: scripts/ci/release-npm.sh
+          publish: scripts/ci/release-both.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 These models are used to communicate with the Apps Rendering API
 
-## How to release to NPM
+## How to release to NPM and Sonatype
 
 This repository uses [`changesets`](https://github.com/changesets/changesets) to manage versions and releases.
 
@@ -21,21 +21,3 @@ To create a changeset, ensure you are using the correct Node (and associated npm
     - You must also create a tag for the snapshot release. Use the following format: `v0.0.0-YYYY-MM-DD-SNAPSHOT`. For example, `v0.0.0-2022-10-20-SNAPSHOT`. It is important the tag **begins** with `v` and **ends** with `-SNAPSHOT`.
     - To automatically release the snapshot to `npm` and `sonatype`, publish the prerelease
     - Snapshots are released to the `snapshot` tag on `npm`. You can install them with `npm install @guardian/apps-rendering-api-models@snapshot`
-
-## How to release to Sonatype
-
-Prerequisites:
-
-- a Sonatype account with access to the guardian organisation
-
-Steps:
-
-- Having followed the instructions in [How to release to NPM](#how-to-release-to-npm) (including merging the "Release PR"):
-    - switch to branch `main` and `git pull`
-- In the SBT repl:
-
-```sbtshell
-clean
-project scalaApiModels
-release with-defaults
-```

--- a/scripts/ci/release-both.sh
+++ b/scripts/ci/release-both.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Configuring GPG"
+scripts/ci/configure-gpg.sh
+
+echo "Releasing to Sonatype"
+scripts/ci/release-sonatype.sh
+
+echo "Releasing to NPM"
+scripts/ci/release-npm.sh

--- a/scripts/ci/release-npm.sh
+++ b/scripts/ci/release-npm.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+npm config set ignore-scripts true
+
 pushd $(dirname $0)
 VERSION=$(./get-version.sh)
 popd

--- a/scripts/ci/release-sonatype.sh
+++ b/scripts/ci/release-sonatype.sh
@@ -4,11 +4,6 @@ pushd $(dirname $0)
 VERSION=$(./get-version.sh)
 popd
 
-# If we are in CI and this is a snapshot release, we should get the version from the tag created in the GitHub Release
-if [[ $CI ]] ; then
-    VERSION=$(git describe --tags)
-fi
-
 # Strip a leading "v" character, so "v0.0.0 => 0.0.0"
 if [[ ${VERSION:0:1} == "v" ]] ; then
     VERSION=${VERSION:1}

--- a/scripts/ci/release-sonatype.sh
+++ b/scripts/ci/release-sonatype.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+pushd $(dirname $0)
+VERSION=$(./get-version.sh)
+popd
+
+# If we are in CI and this is a snapshot release, we should get the version from the tag created in the GitHub Release
+if [[ $CI ]] ; then
+    VERSION=$(git describe --tags)
+fi
+
+# Strip a leading "v" character, so "v0.0.0 => 0.0.0"
+if [[ ${VERSION:0:1} == "v" ]] ; then
+    VERSION=${VERSION:1}
+fi
+
+# sbt-release uses -SNAPSHOT suffix to make the release to the SNAPSHOT channel
+if [[ ${VERSION: -9} == "-SNAPSHOT" ]] ; then
+    echo "Version must not end in -SNAPSHOT"
+    exit 1
+fi
+
+echo "Releasing version $VERSION Sonatype"
+sbt "clean" "project scalaApiModels" "release release-version $VERSION with-defaults"


### PR DESCRIPTION
## What does this change?

- Adds a script to release to both `npm` and Sonatype when a "Release PR" is merged