### PR TITLE
Do not set version in `version.sbt`

### DIFF
--- a/models/scala/version.sbt
+++ b/models/scala/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "1.1.1"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "These models are used to communicate with the Apps Rendering API",
   "private": true,
   "scripts": {
-    "version": "changeset version",
-    "postversion": "./scripts/ci/update-version-sbt.sh"
+    "version": "changeset version"
   },
   "repository": {
     "type": "git",

--- a/scripts/ci/update-version-sbt.sh
+++ b/scripts/ci/update-version-sbt.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-pushd $(dirname $0)
-VERSION=$(./get-version.sh)
-popd
-
-echo "ThisBuild / version := \"$VERSION\"" > ./models/scala/version.sbt


### PR DESCRIPTION
## What does this change?

- We no longer use version.sbt to set the release version
  - Instead, we set versions explicitly when calling sbt commands. The version is derived from git tags for Snapshot releases, or `package.json` for full releases
