### PR TITLE
Bump CAPI Models 17.4.0

### DIFF
--- a/.changeset/soft-insects-dance.md
+++ b/.changeset/soft-insects-dance.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": major
+---
+
+Bumping content-api-models version to "17.4.0". This version adds Callout to the CAPI thrift model as per this pr https://github.com/guardian/content-api-models/pull/216

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 val contentEntityVersion = "2.2.1"
 val contentAtomVersion = "3.4.0"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "17.3.0"
+val contentApiModelsVersion = "17.4.0"
 
 val scroogeDependencies = Seq(
   "content-api-models",


### PR DESCRIPTION
## What does this change?
bumps the version on content api models to 17.4.0 for the new callout element type introduced here https://github.com/guardian/content-api-models/pull/216