### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/apps-rendering @guardian/mss-admins


### PR DESCRIPTION
## What does this change?

- GitHub teams @guardian/apps-rendering and @guardian/mss-admins should be codeowners for all changes in this repository as changes to these models affect both Apps Rendering and MAPI
