### PR TITLE
do not release to Sonatype if the version is already released

### DIFF
--- a/scripts/ci/release-sonatype.sh
+++ b/scripts/ci/release-sonatype.sh
@@ -15,5 +15,9 @@ if [[ ${VERSION: -9} == "-SNAPSHOT" ]] ; then
     exit 1
 fi
 
-echo "Releasing version $VERSION Sonatype"
-sbt "clean" "project scalaApiModels" "release release-version $VERSION with-defaults"
+if ! scripts/ci/version-exists-sonatype.sh $VERSION ; then
+    echo "Releasing version $VERSION Sonatype"
+    sbt "clean" "project scalaApiModels" "release release-version $VERSION with-defaults"
+else
+    echo "Not releasing"
+fi

--- a/scripts/ci/version-exists-sonatype.sh
+++ b/scripts/ci/version-exists-sonatype.sh
@@ -10,7 +10,7 @@ then
 fi
 
 # Get just the http status from the request
-HTTP_STATUS=$(curl -s -o /dev/null -I -w "%{http_code}" https://repo1.maven.org/maven2/com/gu/apps-rendering-api-models_2.12/$VERSION)
+HTTP_STATUS=$(curl -s -o /dev/null -I -w "%{http_code}" https://oss.sonatype.org/service/local/repositories/releases/content/com/gu/apps-rendering-api-models_2.12/$VERSION/)
 
 # 404 is our failure state, as the version wasn't found so it hasn't been released yet
 if [[ $HTTP_STATUS == 404 ]]

--- a/scripts/ci/version-exists-sonatype.sh
+++ b/scripts/ci/version-exists-sonatype.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+# The first argument to this script should be the version to check
+VERSION=$1
+
+if [[ -z "$VERSION" ]]
+then
+    echo "Please call this script with a version to check: ./version-exists-sonatype.sh 1.1.1"
+    exit 1
+fi
+
+# Get just the http status from the request
+HTTP_STATUS=$(curl -s -o /dev/null -I -w "%{http_code}" https://repo1.maven.org/maven2/com/gu/apps-rendering-api-models_2.12/$VERSION)
+
+# 404 is our failure state, as the version wasn't found so it hasn't been released yet
+if [[ $HTTP_STATUS == 404 ]]
+then
+    echo "Version $VERSION does not exist in Sonatype"
+    exit 1
+else
+    echo "Version $VERSION already exists in Sonatype"
+    exit 0
+fi


### PR DESCRIPTION
## What does this change?

- Adds a check to ensure the version being released does not already exist in Sonatype before trying to release. This is intended to prevent failed workflow runs in GitHub Actions
