### PR TITLE
explicitly set isSnapshot for sonatype releases

### DIFF
--- a/scripts/ci/release-snapshot-sonatype.sh
+++ b/scripts/ci/release-snapshot-sonatype.sh
@@ -21,4 +21,4 @@ if [[ ${VERSION: -9} != "-SNAPSHOT" ]] ; then
 fi
 
 echo "Releasing version $VERSION Sonatype as snapshot"
-sbt "clean" "project scalaApiModels" "release release-version $VERSION with-defaults"
+sbt "clean" "project scalaApiModels" "set isSnapshot := true" "release release-version $VERSION with-defaults"

--- a/scripts/ci/release-sonatype.sh
+++ b/scripts/ci/release-sonatype.sh
@@ -16,4 +16,4 @@ if [[ ${VERSION: -9} == "-SNAPSHOT" ]] ; then
 fi
 
 echo "Releasing version $VERSION Sonatype"
-sbt "clean" "project scalaApiModels" "release release-version $VERSION with-defaults"
+sbt "clean" "project scalaApiModels" "set isSnapshot := false" "release release-version $VERSION with-defaults"


### PR DESCRIPTION
## What does this change?

- sbt can indicate a snapshot release when it's a non-snapshot release
  - for example, [this action run](https://github.com/guardian/apps-rendering-api-models/actions/runs/3427400645/jobs/5710855280#step:5:132) stopped short of publishing the package to Sonatype. It should have completed the publish, because `isSnapshot` was `true`. I expect this is because we are not using a `version.sbt` file