### PR TITLE
feat: refactor Related  Content

### DIFF
--- a/.changeset/pink-ligers-shake.md
+++ b/.changeset/pink-ligers-shake.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": minor
+---
+
+Add field `newRelatedContent` which represents Related Content with the CAPI content model

--- a/.changeset/pink-ligers-shake.md
+++ b/.changeset/pink-ligers-shake.md
@@ -2,4 +2,4 @@
 "apps-rendering-api-models": minor
 ---
 
-Add field `newRelatedContent` which represents Related Content with the CAPI content model
+Add field `onwardsContent` which represents Onwards Content with the CAPI content model

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -60,7 +60,7 @@ enum OnwardsContentCategory {
 
 struct OnwardsContent {
     1: required OnwardsContentCategory category
-    2: required list<v1.Content> onwardsItems
+    2: required list<v1.Content> content
 }
 
 struct Branding {

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -53,9 +53,10 @@ struct RelatedContent {
 enum OnwardsContentCategory {
     PAID,
     GALLERY,
-    SPORTS,
+    SPORT,
     STORY_PACKAGE,
-    DEFAULT
+    SERIES,
+    RELATED
 }
 
 struct OnwardsContent {

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -50,6 +50,11 @@ struct RelatedContent {
     2: required list<RelatedItem> relatedItems
 }
 
+struct NewRelatedContent {
+    1: required string title
+    2: required list<v1.Content> relatedItems
+}
+
 struct Branding {
     1: required string brandingType
     2: required string sponsorName
@@ -181,9 +186,19 @@ struct RenderingRequest {
      * That field contains more possible types of campaign.
      */
     // 6: optional list<Campaign> campaigns
+    /*
+     * This field will be deprecated in the next major version, in favour of field number 12
+    */
     7: optional RelatedContent relatedContent
     8: optional FootballContent footballContent
     9: optional Edition edition
     10: optional Newsletter promotedNewsletter
     11: optional list<Campaign> campaigns
+    /*
+     * Field 12 will supersede field 7
+     * To ensure we don't lose related content whilst MAPI and AR
+     * use different versions of these models, we should populate both
+     * fields until the transition is complete.
+    */
+    12: optional NewRelatedContent newRelatedContent
 }

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -50,8 +50,16 @@ struct RelatedContent {
     2: required list<RelatedItem> relatedItems
 }
 
+enum OnwardsContentCategory {
+    PAID,
+    GALLERY,
+    SPORTS,
+    STORY_PACKAGE,
+    DEFAULT
+}
+
 struct OnwardsContent {
-    1: required string title
+    1: required OnwardsContentCategory category
     2: required list<v1.Content> onwardsItems
 }
 

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -50,9 +50,9 @@ struct RelatedContent {
     2: required list<RelatedItem> relatedItems
 }
 
-struct NewRelatedContent {
+struct OnwardsContent {
     1: required string title
-    2: required list<v1.Content> relatedItems
+    2: required list<v1.Content> onwardsItems
 }
 
 struct Branding {
@@ -200,5 +200,5 @@ struct RenderingRequest {
      * use different versions of these models, we should populate both
      * fields until the transition is complete.
     */
-    12: optional NewRelatedContent newRelatedContent
+    12: optional OnwardsContent onwardsContent
 }


### PR DESCRIPTION
## What does this change?

- Adds an optional new field `newRelatedContent` which models related content using the CAPI content model

## How to test

- Release a snapshot version of the models to test it works as intended

## How to release the whole change

Because we can't guarantee both MAPI and AR will be running the same version of the models during the upgrade phase, we should release this by:

- [ ] Implement population of both fields `relatedContent` and `newRelatedContent` in MAPI
- [ ] Implement usage of `newRelatedContent` if populated in AR
- [ ] Make a `major` bump of these models to
  - deprecate `relatedContent`
  - rename `newRelatedContent` => `relatedContent`
- [ ] release the new `major` version to both platforms