### PR TITLE
Add europe edition to ar thrift

### DIFF
--- a/.changeset/wild-badgers-confess.md
+++ b/.changeset/wild-badgers-confess.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": major
+---
+
+Adding Europe edition to Editions enum

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -21,7 +21,8 @@ enum Edition {
     UK,
     US,
     AU,
-    INTERNATIONAL
+    INTERNATIONAL,
+    EUROPE
 }
 
 struct Image {


### PR DESCRIPTION
## What does this change?

Adds `Europe` to editions enum as part of the work to create a new Europe edition.

## How to test

This has been tested with related MAPI changes in CODE. (MAPI [PR](https://github.com/guardian/mobile-apps-api/pull/2126))
