### PR TITLE
add Newsletter.regionFocus and Newsletter.paused

### DIFF
--- a/.changeset/curvy-experts-wait.md
+++ b/.changeset/curvy-experts-wait.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": minor
+---
+
+add Newsletter.paused and Newsletter.regionFocus

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -168,6 +168,8 @@ struct Newsletter {
     4: required string description
     5: required string frequency
     6: required string successDescription
+    7: optional string regionFocus
+    8: required boolean paused
 }
 
 struct RenderingRequest {

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -169,7 +169,7 @@ struct Newsletter {
     5: required string frequency
     6: required string successDescription
     7: optional string regionFocus
-    8: required boolean paused
+    8: optional boolean paused
 }
 
 struct RenderingRequest {

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -169,7 +169,7 @@ struct Newsletter {
     5: required string frequency
     6: required string successDescription
     7: optional string regionFocus
-    8: optional boolean paused
+    8: optional bool paused
 }
 
 struct RenderingRequest {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apps-rendering-api-models",
-  "version": "1.1.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "apps-rendering-api-models",
-      "version": "1.1.1",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@changesets/cli": "^2.25.2"


### PR DESCRIPTION
## What does this change?

Adds two new properties to the Newsletter - these exist on the underlying data source (https://github.com/guardian/newsletters). For some new features, we'll to surface them in the frontend.

```
struct Newsletter {
    1: required string identityName
    2: required string name
    3: required string theme
    4: required string description
    5: required string frequency
    6: required string successDescription
    7: optional string regionFocus
    8: optional bool paused
}
```