### PR TITLE
Bump content-api-models version to 17.4.2

### DIFF
--- a/.changeset/bright-cows-greet.md
+++ b/.changeset/bright-cows-greet.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": minor
+---
+
+Bumping content-api-models version to "17.4.2". This version includes a showTableOfContents bool as per this PR https://github.com/guardian/content-api-models/pull/217.

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 val contentEntityVersion = "2.2.1"
 val contentAtomVersion = "3.4.0"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "17.4.0"
+val contentApiModelsVersion = "17.4.2"
 
 val scroogeDependencies = Seq(
   "content-api-models",


### PR DESCRIPTION
## What does this change?
Bumps content-api-models version to 17.4.2. This version includes the `showTableOfContents` boolean as per this [PR](https://github.com/guardian/content-api-models/pull/217)

We need to include the `showTableOfContents` bool in order to determine whether the table of contents should be shown in an article.
