### PR TITLE
Move Snyk To Dotcom Project

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,7 +14,7 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       DEBUG: true
-      ORG: guardian-mobile
+      ORG: guardian-dotcom-n2y
       JAVA_VERSION: 8
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Why?

The Dotcom team is now maintaining AR.

Paired with @ioannakok @Georges-GNM 

## Changes

- Move Snyk to upload to Dotcom project
