### PR TITLE
make `@guardian/dotcom-platform` codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @guardian/apps-rendering @guardian/mss-admins
+* @guardian/dotcom-platform @guardian/mss-admins


### PR DESCRIPTION
## What does this change?

- Removes `@guardian/apps-rendering` as a codeowner, as the apps rendering team has been merged into the WebX team
- Adds `@guardian/dotcom-platform` as a codeowner, as this team now maintains this repository