### PR TITLE
Add 2 new fields to the contacts array on the callout campaign

### DIFF
--- a/.changeset/blue-moons-sort.md
+++ b/.changeset/blue-moons-sort.md
@@ -1,5 +1,0 @@
----
-"apps-rendering-api-models": minor
----
-
-This adds 2 additional fields to the contacts array on the callout campaign

--- a/.changeset/lovely-pens-lay.md
+++ b/.changeset/lovely-pens-lay.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": major
+---
+
+This breaking changes adds 2 additional fields to the contacts array on the callout campaign - urlPrefix, which is required, and guidance, which is optional


### PR DESCRIPTION
## What does this change?
The targeting-client was updated the model to include a prefixURL, and a guidance link. This will allow additional contact types to be added more easily in the future.