### PR TITLE
Set field IDs for Contact struct

### DIFF
--- a/.changeset/brave-deers-grin.md
+++ b/.changeset/brave-deers-grin.md
@@ -1,5 +1,5 @@
 ---
-"apps-rendering-api-models": minor
+"apps-rendering-api-models": patch
 ---
 
 Fixes the Contact field ids which prevented model compilation

--- a/.changeset/brave-deers-grin.md
+++ b/.changeset/brave-deers-grin.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": minor
+---
+
+Fixes the Contact field ids which prevented model compilation

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -112,8 +112,8 @@ struct SurveyFields {
 struct Contact {
     1: required string name
     2: required string value
-    2: required string urlPrefix
-    2: optional string guidance
+    3: required string urlPrefix
+    4: optional string guidance
 }
 
 struct ParticipationFields {


### PR DESCRIPTION
## What does this change?

- Updates the field IDs for the `Contact` struct. These need to be unique, otherwise the model compilation fails (https://github.com/guardian/apps-rendering-api-models/actions/runs/4075726038/jobs/7022509922#step:5:77)

## Future improvements to this repository

It would have been good if the automated checks caught this failure before attempting a release