### PR TITLE
add GitHub workflow for testing whether a model is valid

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 8
+          cache: sbt
+      
+      - name: Test model
+        run: sbt "clean" "project scalaApiModels" "set isSnapshot := false" "compile"

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -112,7 +112,7 @@ struct SurveyFields {
 struct Contact {
     1: required string name
     2: required string value
-    3: required string urlPrefix
+    2: required string urlPrefix
     4: optional string guidance
 }
 

--- a/models/src/main/thrift/appsRendering.thrift
+++ b/models/src/main/thrift/appsRendering.thrift
@@ -112,7 +112,7 @@ struct SurveyFields {
 struct Contact {
     1: required string name
     2: required string value
-    2: required string urlPrefix
+    3: required string urlPrefix
     4: optional string guidance
 }
 


### PR DESCRIPTION
## What does this change?

- adds the `test` workflow which compiles the model on a PR or push to `main`. The check should fail if the model does not compile, preventing the PR from being merged

## Why are we doing this?

There is currently no automated check to validate the thrift model. This resulted in a situation where we tried to release a version of the package which included an invalid model. The release failed, but we should have found out  about the issue earlier in the release lifecycle, before merging to `main`.

## How to test

- [Example of the failing workflow](https://github.com/guardian/apps-rendering-api-models/actions/runs/4083658712/jobs/7039445252) on this branch when there is an error in the model