### PR TITLE
Bump version of content-api-models

### DIFF
--- a/.changeset/real-crabs-develop.md
+++ b/.changeset/real-crabs-develop.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": minor
+---
+
+This changes pulls in the latest version of content-api-models

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 val contentEntityVersion = "2.2.1"
 val contentAtomVersion = "3.4.0"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "17.4.2"
+val contentApiModelsVersion = "17.6.2"
 
 val scroogeDependencies = Seq(
   "content-api-models",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Pulls in the latest version of content-api-models, which includes overrideTitle, overridePrompt and overrideDescription on the callout element.