### PR TITLE
Attempt to fix changesets workflow

### DIFF
--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -9,6 +9,9 @@ jobs:
   create_release_pr:
     name: Create release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Possibly due to the trial of GitHub Enterprise, the changesets workflow is failing:

https://github.com/guardian/apps-rendering-api-models/actions/runs/5190780469/jobs/9357704131

...it no longer has the rights to push a tag:

```
/usr/bin/git push origin --tags
remote: Permission to guardian/apps-rendering-api-models.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/guardian/apps-rendering-api-models/': The requested URL returned error: 403
Error: Error: The process '/usr/bin/git' failed with exit code 128
Error: The process '/usr/bin/git' failed with exit code 128
```

@JamieB-gu pointed to [this chat](https://chat.google.com/room/AAAAag0I08g/ARIfdbu0axg) about the issue.

It seems we now need to explicitly grant workflows permissions in the yaml definition - our `scripts/ci/release-both.sh` script needs to be able to push tags.
