### PR TITLE
Is the `pull-requests: write` permission required here?

### DIFF
--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
One thing I'm not certain about is whether we actually need the `pull-requests: write` permission explicitly stated here, or whether `contents: write` would have been enough. The changeset app should be getting the pull-requests: write permission from its own definition?

https://github.com/guardian/apps-rendering-api-models/pull/54#issuecomment-1579138804
