### PR TITLE
Revert "Is the `pull-requests: write` permission required here?"

### DIFF
--- a/.github/workflows/changesets.yaml
+++ b/.github/workflows/changesets.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Reverts guardian/apps-rendering-api-models#57 - it _was_ required:

https://github.com/guardian/apps-rendering-api-models/actions/runs/5200933865/jobs/9380367083#step:5:58

```
To https://github.com/guardian/apps-rendering-api-models
 * [new branch]      HEAD -> changeset-release/main
{
  "total_count": 0,
  "incomplete_results": false,
  "items": []
}
creating pull request
Error: HttpError: Resource not accessible by integration
Error: Resource not accessible by integration
```