### PR TITLE
Give read permission to the `release-snapshot` workflow

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release_npm:
     if: "github.event.release.prerelease"


### PR DESCRIPTION
We were seeing [workflow failures](https://github.com/guardian/apps-rendering-api-models/actions/runs/6587440031/job/17897727511) indicating this might be the cause.
