### PR TITLE
Bump CAPI version to 17.7.0

### DIFF
--- a/.changeset/tidy-keys-ring.md
+++ b/.changeset/tidy-keys-ring.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": minor
+---
+
+Bumping content-api-models version to "17.7.0". This version includes the cartoon element defintion (https://github.com/guardian/content-api-models/pull/223) and adding the isMandatory field to the AssetFields (https://github.com/guardian/content-api-models/pull/222)

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 val contentEntityVersion = "2.2.1"
 val contentAtomVersion = "3.4.0"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "17.6.2"
+val contentApiModelsVersion = "17.7.0"
 
 val scroogeDependencies = Seq(
   "content-api-models",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apps-rendering-api-models",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "apps-rendering-api-models",
-      "version": "6.1.3",
+      "version": "6.1.4",
       "license": "ISC",
       "dependencies": {
         "@changesets/cli": "^2.26.1"


### PR DESCRIPTION
## What does this change?
This bumps the CAPI API model version to support some recent changes, namely the definition for the cartoon element and the `isMandatory` field for assets, in the app. This bump is required in order to complete the work to support the cartoon element in the Editions app. This is a companion pr for - https://github.com/guardian/dotcom-rendering/pull/9416

## How to test
This has been published as a snapshot and can be checked in the apps rendering companion pr - https://github.com/guardian/dotcom-rendering/pull/9416