### PR TITLE
Bump CAPI to 19.0.0

### DIFF
--- a/.changeset/cold-gifts-love.md
+++ b/.changeset/cold-gifts-love.md
@@ -1,0 +1,7 @@
+---
+"apps-rendering-api-models": major
+---
+
+Update dependencies to latest
+
+Content API models and Content Atom models libraries have added new fields making them binary incompatible, so this is a major release of apps-rendering-api-models

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 import ReleaseTransformations._
 
 val contentEntityVersion = "2.2.1"
-val contentAtomVersion = "3.4.0"
+val contentAtomVersion = "4.0.0"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "17.7.0"
+val contentApiModelsVersion = "19.0.0"
 
 val scroogeDependencies = Seq(
   "content-api-models",


### PR DESCRIPTION
## What does this change?

Bumps the CAPI and content atoms model versions on this project so that I can bump the commercial-shared version on MAPI.