### PR TITLE
Bump `contentApiModelsVersion`

### DIFF
--- a/.changeset/kind-forks-wash.md
+++ b/.changeset/kind-forks-wash.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": major
+---
+
+This changes pulls in the latest version of content-api-models

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 val contentEntityVersion = "2.2.1"
 val contentAtomVersion = "4.0.0"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "20.1.0"
+val contentApiModelsVersion = "23.0.0"
 
 val scroogeDependencies = Seq(
   "content-api-models",


### PR DESCRIPTION
## What does this change?

Bumps the version of CAPI models to include the new timeline element