### PR TITLE
Bump `contentApiModelsVersion` to 25.0.0

### DIFF
--- a/.changeset/late-forks-confess.md
+++ b/.changeset/late-forks-confess.md
@@ -1,0 +1,5 @@
+---
+"apps-rendering-api-models": minor
+---
+
+Bump content-api-models version to 25.0.0 in order to pull in new ListElement fields used by Mini

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 val contentEntityVersion = "2.2.1"
 val contentAtomVersion = "4.0.0"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "23.0.0"
+val contentApiModelsVersion = "25.0.0"
 
 val scroogeDependencies = Seq(
   "content-api-models",

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import ReleaseTransformations._
 
-val contentEntityVersion = "2.2.1"
+val contentEntityVersion = "3.0.3"
 val contentAtomVersion = "4.0.0"
 val storyPackageVersion = "2.2.0"
 val contentApiModelsVersion = "25.0.0"


### PR DESCRIPTION
## What does this change?

This PR bumps the `content-api-models` version to 25.0.0 in order to pull in new ListElement fields that will be used by Mini profiles format
