### PR TITLE
Move artifactProductionSettings into the right place

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ val artifactProductionSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .settings(artifactProductionSettings)
   .aggregate(scalaApiModels)
   .settings(
     publish / skip := true,
@@ -60,7 +59,7 @@ lazy val root = (project in file("."))
   )
 
 lazy val scalaApiModels = project.in(file("models") / "scala")
-  .settings(commonSettings)
+  .settings(artifactProductionSettings, commonSettings)
   .settings(
     name := "apps-rendering-api-models",
     scalacOptions := Seq("-release:11"),


### PR DESCRIPTION
…after this error: https://github.com/guardian/apps-rendering-api-models/actions/runs/9677187765/job/26698313373#step:5:74

You can see that we were trying to download something that had a group ID of "apps-rendering-api-models" rather than "com.gu", so the download failed.

This was due to a misconfiguration in [the previous PR](https://github.com/guardian/apps-rendering-api-models/pull/90).