### PR TITLE
Ensure that we do not try to publish typescript classes to maven central

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ lazy val tsApiModels = project.in(file("models") / "ts")
   .enablePlugins(ScroogeTypescriptGen)
   .settings(commonSettings)
   .settings(
+    publish / skip := true,
     name := "apps-rendering-api-models-ts",
     scroogeTypescriptNpmPackageName := "@guardian/apps-rendering-api-models",
     Compile / scroogeDefaultJavaNamespace := scroogeTypescriptNpmPackageName.value,


### PR DESCRIPTION
## What does this change?

We spotted that this bit of configuration was missing from `build.sbt` - here it is serving the same purpose in `content-entity`: https://github.com/guardian/content-entity/blob/e3a6e8f28f44a44065fb001c0cf5e74361c35a90/build.sbt#L75C5-L75C36
