### PR TITLE
Update release badges on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Apps Rendering API Models
 
-![npm](https://img.shields.io/npm/v/@guardian/apps-rendering-api-models)
+[![npm](https://img.shields.io/npm/v/@guardian/apps-rendering-api-models)](https://www.npmjs.com/package/@guardian/apps-rendering-api-models?activeTab=versions)
 [![apps-rendering-api-models Scala version support](https://index.scala-lang.org/guardian/apps-rendering-api-models/apps-rendering-api-models/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/apps-rendering-api-models/apps-rendering-api-models)
+[![Release](https://github.com/guardian/apps-rendering-api-models/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/apps-rendering-api-models/actions/workflows/release.yml)
 
 This project contains Thrift models and a way to publish them as Scala and TypeScript packages. MAPI uses the Scala package to send data to the Apps Rendering API, which uses the TypeScript package to deserialise the data. These two projects can be found here:
 


### PR DESCRIPTION
Two changes:

* [![Release](https://github.com/guardian/apps-rendering-api-models/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/apps-rendering-api-models/actions/workflows/release.yml) - a new 'Release' badge, linking straight to the Release workflow added in https://github.com/guardian/apps-rendering-api-models/pull/90 - a quick way to get to the place where you can make a release, and a status indicator showing if the last release failed.
* [![npm](https://img.shields.io/npm/v/@guardian/apps-rendering-api-models)](https://www.npmjs.com/package/@guardian/apps-rendering-api-models?activeTab=versions) - updating the NPM badge to link to the project on npmjs.com, always convenient when debugging the release process!
