### PR TITLE
update content-api-models to 26.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 val contentEntityVersion = "3.0.3"
 val contentAtomVersion = "4.0.4"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "25.1.1"
+val contentApiModelsVersion = "26.0.0"
 
 val scroogeDependencies = Seq(
   "content-api-models",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR updates `content-api-models` to `26.0.0`. 

In PR https://github.com/guardian/apps-rendering-api-models/pull/98 multiple updates were introduced, but conflicts arose during the process. To make troubleshooting easier, I’m splitting those updates into smaller, more focused sub-updates, starting with this one.

Updates in PR #98 that are not applied in this PR:
- content-atom-model-thrift => 
  - updating content-entity-thrift from 3.0.3 to 4.0.0 
  - libthrift from 0.15.0 to 0.20.0
- content-entity-thrift => 
  - updating libthrift from 0.19.0 to 0.20.0
- sbt-scrooge-typescript plugin => 
  - This one causes error: com.twitter.scrooge.frontend.FileParseException: Exception parsing: appsRendering.thrift

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
