### PR TITLE
Update content api models to v27.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 val contentEntityVersion = "3.0.3"
 val contentAtomVersion = "4.0.4"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "26.0.0"
+val contentApiModelsVersion = "27.0.0"
 
 val scroogeDependencies = Seq(
   "content-api-models",


### PR DESCRIPTION
## What does this change?

Model upgrade, so that we can bump the content api scala client version in MAPI