### PR TITLE
Update content atom model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import ReleaseTransformations._
 import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 val contentEntityVersion = "3.0.3"
-val contentAtomVersion = "4.0.4"
+val contentAtomVersion = "6.1.0"
 val storyPackageVersion = "2.2.0"
-val contentApiModelsVersion = "27.0.0"
+val contentApiModelsVersion = "31.0.0"
 
 val scroogeDependencies = Seq(
   "content-api-models",


### PR DESCRIPTION
* Brings in https://github.com/guardian/content-atom/releases/tag/v6.1.0.
* Brings in https://github.com/guardian/content-api-models/releases/tag/v31.0.0, which transiently brings in https://github.com/guardian/content-atom/releases/tag/v6.1.0.